### PR TITLE
Add missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from distutils.core import setup
 from setuptools import find_packages
 
 
-required = []
+required = ['numpy', 'scipy', 'pandas', 'patsy', 'statsmodels', 'matplotlib']
 
 setup(
     name="ggplot",
-    version="0.2.5",
+    version="0.2.6",
     author="Greg Lamp",
     author_email="greg@yhathq.com",
     url="https://github.com/yhat/ggplot/",


### PR DESCRIPTION
ggplot's requirements are currently missing, which makes pip installs appear to succeed (when they will not work).

I also bumped the version number up so that you can successfully add this updated setup.py file to pypi.
