### PR TITLE
make ggplot\example.py code runable under ipython, or from another user directory

### DIFF
--- a/example.py
+++ b/example.py
@@ -5,7 +5,9 @@ import pandas as pd
 import numpy as np
 from ggplot import *
 
-meat = pd.read_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ggplot', 'exampledata', 'meat.csv'))
+import ggplot as gg
+os.path.join(os.path.dirname(gg.__file__),   'exampledata', 'meat.csv')
+meat = pd.read_csv(os.path.join(os.path.dirname(gg.__file__),   'exampledata', 'meat.csv'))
 meat['date'] = pd.to_datetime(meat.date)
 
 df = pd.DataFrame({
@@ -100,7 +102,11 @@ p = ggplot(aes(x='date', y='beef'), data=meat)
 
 p = ggplot(aes(x='factor(cyl)'), data=mtcars)
 print(p + geom_bar())
-plt.show(block=True)
+try:
+    __IPYTHON__ 
+    plt.show()
+except: 
+    plt.show(block=True)
 #ggsave(p + geom_bar(), "public/img/mtcars_geom_bar_cyl.png")
 
 p = ggplot(aes(x='date_hour', y='pageviews'), data=pageviews)


### PR DESCRIPTION
Hello,

A new user trying to copy/paste under Ipython the code from "example.py" will get two errors (below).
The patch should avoid the two errors, and allows to register the example anywhere in the user's computer.

NOTA
To get the directory of a module, It seems we need to import it under a name.
==> So I imported it a second time with "import ggplot as gg".
==> Maybe there is a better way ?

```
:\Users\famille\Documents\winpython\WinPython-32bit-3.3.2.3ggplot\python-3.3.2\lib\site-packages\matplotlib\pyplot.py in show(*args, **kw)
    143     """
    144     global _show
--> 145     _show(*args, **kw)
    146 
    147 

TypeError: show() got an unexpected keyword argument 'block'
```

```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-5-586fe923539b> in <module>()
      5 from ggplot import *
      6 
----> 7 meat = pd.read_csv(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'ggplot', 'exampledata', 'meat.csv'))
      8 meat['date'] = pd.to_datetime(meat.date)
      9 

NameError: name '__file__' is not defined

```
