### PR TITLE
fix aes(): allow mixed positional and keyword arguments

### DIFF
--- a/ggplot/components/aes.py
+++ b/ggplot/components/aes.py
@@ -52,11 +52,12 @@ class aes(UserDict):
         if args:
             self.data = dict(zip(self.DEFAULT_ARGS, args))
         else:
-            self.data = kwargs
+            self.data = {}
+        if kwargs:
+            self.data.update(kwargs)
         if 'colour' in self.data:
             self.data['color'] = self.data['colour']
             del self.data['colour']
         if 'linetype' in self.data:
             self.data['linestyle'] = self.data['linetype']
             del self.data['linetype']
-

--- a/ggplot/tests/test_basic.py
+++ b/ggplot/tests/test_basic.py
@@ -114,3 +114,37 @@ def test_smoke():
 
 
 
+def test_aes_positional_args():
+    result = aes("weight", "hp")
+    expected = {"x": "weight", "y": "hp"}
+    print("result:", result)
+    print("expected:", expected)
+    assert result == expected
+
+    result3 = aes("weight", "hp", "qsec")
+    expected3 =  {"x": "weight", "y": "hp", "color": "qsec"}
+    print("result (3 args):", result3)
+    print("expected (3 args):", expected3)
+    assert result3 == expected3
+
+
+def test_aes_keyword_args():
+    result = aes(x="weight", y="hp")
+    expected = {"x": "weight", "y": "hp"}
+    print("result:", result)
+    print("expected:", expected)
+    assert result == expected
+
+    result3 = aes(x="weight", y="hp", color="qsec")
+    expected3 =  {"x": "weight", "y": "hp", "color": "qsec"}
+    print("result (3 args):", result3)
+    print("expected (3 args):", expected3)
+    assert result3 == expected3
+
+
+def test_aes_mixed_args():
+    result = aes("weight", "hp", color="qsec")
+    expected = {"x": "weight", "y": "hp", "color": "qsec"}
+    print("result:", result)
+    print("expected:", expected)
+    assert result == expected


### PR DESCRIPTION
aes() used to silently ignore additional keyword argument if some
positional arguments were used.

aes("x", "y", color="color") is now valid code and equivalent to
aes("x", "y", "color") or aes(x="x", y="y", color="color")
