### PR TITLE
Feature: var names in legends

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -70,7 +70,7 @@ We're looking for contributors! Email greg at yhathq.com for more info.
 - legends:
     - ~~make more consistent / fix spacing~~
     - ~~add support for non-blue continuous colors~~
-    - make the title of each legend the variable, not the aes
+    - ~~make the title of each legend the variable, not the aes~~
     - make the title of the legend configurable
 - themes:
     - look for better ggplot theme

--- a/ggplot/components/legend.py
+++ b/ggplot/components/legend.py
@@ -71,9 +71,9 @@ legend_viz = {
     "size": make_size_key,
 }
 
-def draw_legend(ax, legend, legend_type, ith_legend):
+def draw_legend(ax, legend, legend_type, legend_title, ith_legend):
     children = []
-    children.append(make_title(legend_type))
+    children.append(make_title(legend_title))
     viz_handler = legend_viz[legend_type]
     legend_items = sorted(legend.items(), key=operator.itemgetter(1))
     children += [viz_handler(lab, col) for col, lab in legend_items]

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -258,16 +258,18 @@ class ggplot(object):
                     box = ax.get_position()
                     ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])
                     cntr = 0
-                    for name, legend in self.legend.items():
-                        ax.add_artist(draw_legend(ax, legend, name, cntr))
+                    for ltype, legend in self.legend.items():
+                        lname = self.aesthetics.get(ltype, ltype)
+                        ax.add_artist(draw_legend(ax, legend, ltype, lname, cntr))
                         cntr += 1
             else:
                 box = axs.get_position()
                 axs.set_position([box.x0, box.y0, box.width * 0.8, box.height])
                 cntr = 0
-                for name, legend in self.legend.items():
+                for ltype, legend in self.legend.items():
                     if legend:
-                        axs.add_artist(draw_legend(axs, legend, name, cntr))
+                        lname = self.aesthetics.get(ltype, ltype)
+                        axs.add_artist(draw_legend(axs, legend, ltype, lname, cntr))
                         cntr += 1
 
         # TODO: We can probably get more sugary with this

--- a/tests/test_legend.py
+++ b/tests/test_legend.py
@@ -1,0 +1,6 @@
+from __future__ import print_function
+from ggplot import *
+
+p = ggplot(mtcars, aes(x='qsec', y='mpg', color='cyl', size='hp')) + geom_point()
+print(p)
+plt.show(1)


### PR DESCRIPTION
Make the title of each legend the variable, not the aes.

For example, `ggplot(mtcars, aes(x='qsec', y='mpg', color='cyl', size='hp')) + geom_point()` will produce two legends. Their captions will be "Cyl" and "Hp" respectively.
