### PR TITLE
adding binwidth to geom_histogram with default range/30

### DIFF
--- a/ggplot/geoms/geom_histogram.py
+++ b/ggplot/geoms/geom_histogram.py
@@ -1,12 +1,27 @@
 import matplotlib.pyplot as plt
+import sys
 from copy import deepcopy
 from .geom import geom
 
 
 class geom_histogram(geom):
-    VALID_AES = ['x', 'color', 'alpha', 'label']
+    VALID_AES = ['x', 'color', 'alpha', 'label', 'binwidth']
 
     def plot_layer(self, layer):
         layer = {k: v for k, v in layer.items() if k in self.VALID_AES}
         layer.update(self.manual_aes)
+        if 'binwidth' in layer:
+            binwidth = layer.pop('binwidth')
+            try:
+                binwidth = float(binwidth)
+                bottom = plt.np.nanmin(layer['x'])
+                top = plt.np.nanmax(layer['x'])
+                layer['bins'] = plt.np.arange(bottom, top + binwidth, binwidth)
+            except:
+                pass
+        if 'bins' not in layer:
+            layer['bins'] = 30
+            sys.stderr.write("binwidth defaulted to range/30. " +
+                             "Use 'binwidth = x' to adjust this.\n")
+                
         plt.hist(**layer)

--- a/tests/test_geom_histogram.py
+++ b/tests/test_geom_histogram.py
@@ -4,8 +4,12 @@ from ggplot import *
 class TestGeomHistogram(unittest.TestCase):
 
     def test_geom_histogram(self):
-        gghist = ggplot(meat, aes(x='veal', y='beef')) + geom_histogram()
+        gghist = ggplot(meat, aes(x='veal')) + geom_histogram()
         self.assertTrue(type(gghist) == ggplot)
+        print gghist
+
+    def test_binwidth(self):
+        gghist = ggplot(meat, aes(x='veal') + geom_histogram(binwidth=10)
         print gghist
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding the ability to set the bin width.
The example plot in the readme should be updated, but maybe that can wait until the themes have been sorted out (my axis text is black right now instead of grey).
