### PR TITLE
geom_line: Fix size parameter

### DIFF
--- a/ggplot/geoms/geom_line.py
+++ b/ggplot/geoms/geom_line.py
@@ -6,7 +6,7 @@ from .geom import geom
 
 
 class geom_line(geom):
-    VALID_AES = ['x', 'y', 'color', 'alpha', 'linestyle', 'label', 'size', 'group']
+    VALID_AES = ['x', 'y', 'color', 'alpha', 'group', 'linestyle', 'linewidth' 'label', 'size']
     def plot_layer(self, layer):
         layer = {k: v for k, v in layer.items() if k in self.VALID_AES}
         layer.update(self.manual_aes)
@@ -15,7 +15,7 @@ class geom_line(geom):
         if 'y' in layer:
             y = layer.pop('y')
         if 'size' in layer:
-            layer['markersize'] = layer['size']
+            layer['linewidth'] = layer['size']
             del layer['size']
         if 'linestyle' in layer and 'color' not in layer:
             layer['color'] = 'k'


### PR DESCRIPTION
The size parameter should control the `linewidth` for this type of plot. This will allow users to control the width of the lines on the chart.

Fixes #101
