### PR TITLE
Fix plot display in IPython notebook

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -131,7 +131,8 @@ class ggplot(object):
         figure = self.draw()
         # We're going to default to making the plot appear when __repr__ is
         # called.
-        figure.show()
+        #figure.show() # doesn't work in ipython notebook
+        plt.show()
         # TODO: We can probably get more sugary with this
         return "<ggplot: (%d)>" % self.__hash__()
 


### PR DESCRIPTION
It seems that calling figure.show() is not working in IPython notebook.

Closes #115
