### PR TITLE
force array containing figure axes to be 2d

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -269,9 +269,9 @@ class ggplot(object):
                                         continue
                                     y_i, x_i = pos
                                     pos = x_i + y_i * self.n_high + 1
-                                    plt.subplot(self.n_wide, self.n_high, pos)
+                                    ax = plt.subplot(self.n_wide, self.n_high, pos)
                                 else:
-                                    plt.subplot(self.n_wide, self.n_high, cntr)
+                                    ax = plt.subplot(self.n_wide, self.n_high, cntr)
                                     # TODO: this needs some work
                                     if (cntr % self.n_high)==-1:
                                         plt.tick_params(axis='y', which='both',
@@ -280,7 +280,7 @@ class ggplot(object):
                                 callbacks = geom.plot_layer(layer)
                                 if callbacks:
                                     for callback in callbacks:
-                                        fn = getattr(axs[cntr], callback['function'])
+                                        fn = getattr(ax, callback['function'])
                                         fn(*callback['args'])
                         title = facet
                         if isinstance(facet, tuple):


### PR DESCRIPTION
First I want to say, I'm really grateful for the code so far! I came across an error when trying to plot all of my subplots in one row, instead of a 2D layout.

```
from pandas import DataFrame
from numpy.random import randn
from ggplot import *
letters = ['a','a','a','b','b','b','c','c','c','d','d','d']
colors = ['r','g','b','r','g','b','r','g','b','r','g','b']
values1 = randn(12)
values2 = randn(12)
df = pd.DataFrame({'letter': letters, 'color': colors, \
    'value1': values1, 'value2': values2})

ggplot(aes(x='value1', y='value2', color='color'), df) \
 + geom_point() \
 + facet_wrap('letter', ncol=4)
```

raises the error:

```
//anaconda/lib/python2.7/site-packages/ggplot/ggplot.pyc in draw(self)
    326             if self.legend:
    327                 if self.facets:
--> 328                     ax = axs[0][self.n_wide - 1]
    329                     box = ax.get_position()
    330                     ax.set_position([box.x0, box.y0, box.width * 0.8, box.height])

TypeError: 'AxesSubplot' object does not support indexing
```

The same thing happens when I try nrow=4. It has to do with the fact that plt.subplots() can return either a 1D or 2D array, but ggplot expects all 2D arrays. My quick, one-line fix was to just force the axis array to be 2D. I don't know the code all that well, so I don't know if this is a good fix (doesn't seem to break anything in my non-exhaustive tests), but mostly I wanted to bring this to your attention. Thanks again for your work!
