### PR TITLE
updated subdir extraction in ggplot/tests/__init__.py to handle .pyc files

### DIFF
--- a/ggplot/tests/__init__.py
+++ b/ggplot/tests/__init__.py
@@ -59,7 +59,8 @@ def _assert_same_figure_images(fig, name, test_file, tol=17):
         name = name+".png"
 
     basedir = os.path.abspath(os.path.dirname(test_file))
-    subdir = os.path.basename(test_file).split('.')[0]
+    basename = os.path.basename(test_file)
+    subdir = os.path.splitext(basename)[0]
 
     baseline_dir = os.path.join(basedir, 'baseline_images', subdir)
     result_dir = os.path.abspath(os.path.join('result_images', subdir))


### PR DESCRIPTION
On my system, running the tests twice in a row will cause many errors. This is because .pyc files are being used the second time around which causes the extracted subdir to be incorrect.
