### PR TITLE
Fixes mavg smoother and unsorted x values with smoothers

### DIFF
--- a/ggplot/components/smoothers.py
+++ b/ggplot/components/smoothers.py
@@ -58,13 +58,13 @@ def lowess(x, y, span=SPAN):
     y2 = pd.Series(upper * std +  y)
     return (y, y1, y2)
 
-def mavg(x,y, span=SPAN):
+def mavg(x,y, window):
     "compute moving average"
-    x, y = map(_plot_friendly, [x,y])
+    x, y = map(plot_friendly, [x,y])
     if _isdate(x[0]):
         x = np.array([i.toordinal() for i in x])
-    std_err = pd.expanding_std(y, span)
-    y = pd.rolling_mean(y, span)
+    std_err = pd.rolling_std(y, window)
+    y = pd.rolling_mean(y, window)
     y1 = y - std_err
     y2 = y + std_err
     return (y, y1, y2)

--- a/ggplot/geoms/stat_smooth.py
+++ b/ggplot/geoms/stat_smooth.py
@@ -8,7 +8,7 @@ import numpy as np
 from ggplot.components import smoothers
 
 class stat_smooth(geom):
-    VALID_AES = ['x', 'y', 'color', 'alpha', 'label', 'se', 'linestyle', 'method', 'span', 'level']
+    VALID_AES = ['x', 'y', 'color', 'alpha', 'label', 'se', 'linestyle', 'method', 'span', 'level', 'window']
 
     def plot_layer(self, layer):
         layer = {k: v for k, v in layer.items() if k in self.VALID_AES}
@@ -26,6 +26,10 @@ class stat_smooth(geom):
             span = layer.pop('span')
         else:
             span = 2/3.
+        if 'window' in layer:
+            window = layer.pop('window')
+        else:
+            window = int(np.ceil(len(x) / 10.0))
         if 'level' in layer:
             level = layer.pop('level')
         else:
@@ -34,17 +38,17 @@ class stat_smooth(geom):
             method = layer.pop('method')
         else:
             method = None
-        if method == "lm":
-            y, y1, y2 = smoothers.lm(x, y, 1-level)
-        elif method == "ma":
-            y, y1, y2 = smoothers.mavg(x, y)
-        else:
-            y, y1, y2 = smoothers.lowess(x, y, span=span)
+
         idx = np.argsort(x)
         x = np.array(x)[idx]
         y = np.array(y)[idx]
-        y1 = np.array(y1)[idx]
-        y2 = np.array(y2)[idx]
+
+        if method == "lm":
+            y, y1, y2 = smoothers.lm(x, y, 1-level)
+        elif method == "ma":
+            y, y1, y2 = smoothers.mavg(x, y, window=window)
+        else:
+            y, y1, y2 = smoothers.lowess(x, y, span=span)
         plt.plot(x, y, **layer)
         if se==True:
             plt.fill_between(x, y1, y2, alpha=0.2, color="grey")


### PR DESCRIPTION
This should fix issue #162. I changed the movnig avg 'se' to use rolling_std along with rolling_mean, instead of expanding_std, which is not quite the expected behavior.
