### PR TITLE
Module leaks fixed

### DIFF
--- a/ggplot/__init__.py
+++ b/ggplot/__init__.py
@@ -18,10 +18,10 @@ _set_mpl_backend()
 # version of ggplot.
 __version__ = '0.4.7'
 
-from .ggplot import *
+from .ggplot import ggplot
 from .components import aes
 from .geoms import *
 from .scales import *
 from .themes import *
 from .utils import *
-from .exampledata import *
+from .exampledata import (diamonds,mtcars,meat,pageviews)


### PR DESCRIPTION
In response to issue #207 import statements have been restricted to prevent "leaking" of: `np, pd, sys, os, re, plt`
