### PR TITLE
Fix leaky "from ggplot import *"

### DIFF
--- a/ggplot/exampledata/__init__.py
+++ b/ggplot/exampledata/__init__.py
@@ -4,7 +4,8 @@ import pandas as pd
 import matplotlib.image as mpimg
 import os
 
-__ALL__ = ["diamonds","mtcars","meat","pageviews"]
+__all__ = ["diamonds","mtcars","meat","pageviews"]
+__all__ = [str(u) for u in __all__]
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 diamonds = pd.read_csv(os.path.join(_ROOT, "diamonds.csv"))

--- a/ggplot/geoms/__init__.py
+++ b/ggplot/geoms/__init__.py
@@ -30,6 +30,7 @@ __geoms__ = ['geom_abline', 'geom_area', 'geom_bar', 'geom_density',
              'geom_histogram', 'geom_hline', 'geom_jitter', 'geom_line', 
              'geom_now_its_art', 'geom_point', 'geom_rect', 'geom_step',
              'geom_text', 'geom_tile', 'geom_vline']
-__stats__ = ['stat_bin2d', 'stat_smooth']
+__stats__ = ['stat_bin2d', 'stat_smooth', 'stat_function']
 __components__ = ['ylab', 'xlab', 'ylim', 'xlim', 'labs', 'ggtitle']
-__ALL__ = __geoms__ + __facet__ + __stats__ + __components__
+__all__ = __geoms__ + __facet__ + __stats__ + __components__
+__all__ = [str(u) for u in __all__]

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -11,11 +11,13 @@ from .components import colors, shapes
 from .components.legend import draw_legend
 from .geoms import *
 from .scales import *
+from .scales.utils import calc_axis_breaks_and_limits
 from .themes.theme_gray import _set_default_theme_rcparams
 from .themes.theme_gray import _theme_grey_post_plot_callback
 import six
 
-__ALL__ = ["ggplot"]
+__all__ = ["ggplot"]
+__all__ = [str(u) for u in __all__]
 
 import sys
 import warnings
@@ -359,13 +361,13 @@ class ggplot(object):
                     ax.yaxis.set_major_formatter(self.ytick_formatter)
                 if self.xlimits:
                     if not self.xbreaks and not self.xtick_labels:
-                        labs, minval, maxval= utils.calc_axis_breaks_and_limits(self.xlimits[0], self.xlimits[1])
+                        labs, minval, maxval= calc_axis_breaks_and_limits(self.xlimits[0], self.xlimits[1])
                         ax.xaxis.set_ticks(labs)
                         ax.xaxis.set_ticklabels(labs)
                     ax.set_xlim(self.xlimits)
                 if self.ylimits:
                     if not self.ytick_labels:
-                        labs, minval, maxval= utils.calc_axis_breaks_and_limits(self.ylimits[0], self.ylimits[1])
+                        labs, minval, maxval= calc_axis_breaks_and_limits(self.ylimits[0], self.ylimits[1])
                         ax.yaxis.set_ticks(labs)
                         ax.yaxis.set_ticklabels(labs)
                     ax.set_ylim(self.ylimits)

--- a/ggplot/scales/__init__.py
+++ b/ggplot/scales/__init__.py
@@ -18,10 +18,11 @@ from .scale_log import scale_x_log, scale_y_log
 from .scale_log import scale_x_log as scale_x_log10
 from .scale_log import scale_y_log as scale_y_log10
 
-__ALL__ = ['scale_color_brewer', 'scale_colour_brewer',
+__all__ = ['scale_color_brewer', 'scale_colour_brewer',
            'scale_color_gradient', 'scale_colour_gradient',
            'scale_colour_gradient2', 'scale_colour_manual', 'scale_facet', 
            'scale_facet_grid', 'scale_facet_wrap', 'scale_reverse', 
            'scale_x_continuous', 'scale_x_date', 'scale_x_reverse', 
            'scale_y_continuous', 'scale_y_reverse', 'scale_x_log',
            'scale_y_log', 'scale_x_log10', 'scale_y_log10']
+__all__ = [str(u) for u in __all__]

--- a/ggplot/tests/test_basic.py
+++ b/ggplot/tests/test_basic.py
@@ -11,6 +11,8 @@ assert_same_ggplot = get_assert_same_ggplot(__file__)
 from ggplot import *
 from ggplot.exampledata import diamonds
 
+import numpy as np
+import pandas as pd
 
 def _build_testing_df():
     df = pd.DataFrame({

--- a/ggplot/tests/test_faceting.py
+++ b/ggplot/tests/test_faceting.py
@@ -7,6 +7,7 @@ assert_same_ggplot = get_assert_same_ggplot(__file__)
 
 from ggplot import *
 
+import numpy as np
 import pandas as pd
 
 

--- a/ggplot/tests/test_geom_rect.py
+++ b/ggplot/tests/test_geom_rect.py
@@ -9,6 +9,7 @@ assert_same_ggplot = get_assert_same_ggplot(__file__)
 from ggplot import *
 from ggplot.exampledata import diamonds
 
+import pandas as pd
 
 @cleanup
 def test_geom_rect():

--- a/ggplot/tests/test_readme_examples.py
+++ b/ggplot/tests/test_readme_examples.py
@@ -8,6 +8,7 @@ assert_same_ggplot = get_assert_same_ggplot(__file__)
 
 from ggplot import *
 
+import pandas as pd
 
 @cleanup
 def test_demo_beef():

--- a/ggplot/tests/test_reverse.py
+++ b/ggplot/tests/test_reverse.py
@@ -8,6 +8,8 @@ from ggplot.tests import image_comparison
 
 from ggplot import *
 
+import numpy as np
+import pandas as pd
 
 @image_comparison(baseline_images=['scale_without_reverse', 'scale_y_reverse', 'scale_x_reverse', 'scale_both_reverse'], extensions=["png"])
 def test_scale_reverse():

--- a/ggplot/tests/test_theme_mpl.py
+++ b/ggplot/tests/test_theme_mpl.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import six
 from six.moves import xrange
 
 from nose.tools import assert_equal, assert_true, assert_raises

--- a/ggplot/themes/__init__.py
+++ b/ggplot/themes/__init__.py
@@ -5,5 +5,6 @@ from .theme_xkcd import theme_xkcd
 from .theme_matplotlib import theme_matplotlib
 from .theme_seaborn import theme_seaborn
 
-__ALL__ = ["theme_bw","theme_gray","theme_xkcd","theme_matplotlib",
+__all__ = ["theme_bw","theme_gray","theme_xkcd","theme_matplotlib",
            "theme_seaborn"]
+__all__ = [str(u) for u in __all__]

--- a/ggplot/utils/__init__.py
+++ b/ggplot/utils/__init__.py
@@ -1,8 +1,9 @@
-from .utils import ggsave
+from .utils import ggsave, add_ggplotrc_params
 from .date_breaks import date_breaks
 from .date_format import date_format
 
-__ALL__ = ["ggsave", "date_breaks", "date_format", "add_ggplotrc_params"]
+__all__ = ["ggsave", "date_breaks", "date_format", "add_ggplotrc_params"]
+__all__ = [str(u) for u in __all__]
 
 class _rc_context(object):
     def __init__(self, fname=None):


### PR DESCRIPTION
## Issue

`from ggplot import *`
brings in module level global variables
## Problem
1. `__ALL__` is ignored by the \* import
   2.
   `from __future__ import unicode_literals`
   makes all strings default to unicode. Therefore
   variable names in `__ALL__` are unicode. But
   python 2 variable names are not unicode
## Solution

1.`__all__` instead of `__ALL__`
2. Encode strings in `__all__` as ascii
## References
1. Commit 0cedbacf6917c2ccd0cc81be2100cc747706984e
2. Github Issue #207
3. http://stackoverflow.com/questions/19913653/no-unicode-in-all-for-a-packages-init
