### PR TITLE
geom_bar expanded

### DIFF
--- a/ggplot/geoms/geom_bar.py
+++ b/ggplot/geoms/geom_bar.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from .geom import geom
 from pandas.lib import Timestamp
-
+from ggplot.components.colors import color_gen
 
 class geom_bar(geom):
     VALID_AES = ['x', 'color', 'alpha', 'fill', 'label', 'weight', 'position']
@@ -48,42 +48,37 @@ class geom_bar(geom):
         if 'fill' in layer:
             fill = layer.pop('fill')
             if type(fill) is list:
-                color_cycle = ['r', 'g', 'b', 'y','c', 'm', 'y', 'k']
-                if x == fill:
-                    n_rep = (len(color_cycle) + 1) // len(labels) + 1
-                    layer['color'] = (color_cycle * n_rep)[:len(labels)]
-                else:
-                    position = layer.get('position','stacked')
-                    fill_labels = np.unique(fill).tolist()
-                    bottom = np.zeros(len(labels),dtype=np.int)
-                    color_cycle = ['r', 'g', 'b', 'y','c', 'm', 'y', 'k']
-                    for i,fill_label in enumerate(fill_labels):
-                        color = color_cycle[i % len(color_cycle)]
-                        fill_x = np.array(x)[np.array(fill) == np.array(fill_label)]
-                        counts = pd.value_counts(fill_x)
-                        weights = counts.reindex(labels,fill_value=0).tolist()
-                        if position == 'dodge':
-                            bar_width = width / len(fill_labels)
-                            plt.bar(indentation+(bar_width * i),
-                                    weights,
-                                    bar_width,
-                                    color=color,
-                                    label=fill_label)
-                        else:
-                            plt.bar(indentation,
-                                    weights,
-                                    width,
-                                    color=color,
-                                    bottom=bottom,
-                                    label=fill_label)
-                            bottom += weights
-                        plt.autoscale()
-                    return [
-                        {"function": "set_xticks", "args": [indentation+width/2]},
-                        {"function": "set_xticklabels", "args": [labels]},
-                        {"function": "set_ylabel", "args": ["count"]},
-                        {"function": "legend","args":[]},
-                    ]
+                position = layer.get('position','stacked')
+                fill_labels = np.unique(fill).tolist()
+                bottom = np.zeros(len(labels),dtype=np.int)
+                color_cycle = color_gen(len(fill_labels))
+                for i,fill_label in enumerate(fill_labels):
+                    color = color_cycle.next()
+                    fill_x = np.array(x)[np.array(fill) == np.array(fill_label)]
+                    counts = pd.value_counts(fill_x)
+                    weights = counts.reindex(labels,fill_value=0).tolist()
+                    if position == 'dodge':
+                        bar_width = width / len(fill_labels)
+                        plt.bar(indentation+(bar_width * i),
+                                weights,
+                                bar_width,
+                                color=color,
+                                label=fill_label)
+                    else:
+                        plt.bar(indentation,
+                                weights,
+                                width,
+                                color=color,
+                                bottom=bottom,
+                                label=fill_label)
+                        bottom += weights
+                    plt.autoscale()
+                return [
+                    {"function": "set_xticks", "args": [indentation+width/2]},
+                    {"function": "set_xticklabels", "args": [labels]},
+                    {"function": "set_ylabel", "args": ["count"]},
+                    {"function": "legend","args":[]},
+                ]
             else:
                 layer['color'] = fill
         else:


### PR DESCRIPTION
Attempting to recreate more of the [ggplot2 geom_bar()](http://docs.ggplot2.org/0.9.3.1/geom_bar.html) functionality

Multicolor bar graphs expanded:
`ggplot(mtcars,aes(x='cyl',fill='factor(cyl)')) + geom_bar()`

![bar_factor](https://f.cloud.github.com/assets/2342749/2305544/cdfef9ec-a25b-11e3-956d-0c96afb79ecb.png)

Stacked bar graphs:
`ggplot(diamonds, aes(x='clarity',fill='cut')) + geom_bar()`

![stacked_bar](https://f.cloud.github.com/assets/2342749/2305547/149d2e50-a25c-11e3-9656-f25e42b91852.png)

Side by side bar graphs:
`ggplot(diamonds, aes(x='clarity',fill='cut')) + geom_bar(position='dodge')`

![dodge_bar](https://f.cloud.github.com/assets/2342749/2305546/02a92992-a25c-11e3-83ed-5c429f3c365b.png)

Also, added 'count' to ylab by default:

`ggplot(diamonds,aes(x='color')) + geom_bar()`

![bar_count](https://f.cloud.github.com/assets/2342749/2305549/4f5f7a52-a25c-11e3-94ff-94cc54d3e46d.png)

**ISSUES**:

How do I make the legend appear correctly? The code all seems to be part of `ggplot.py`. Right now I'm hacking by returning the callback `{"function": "legend","args":[]}`, but there must be a better way of doing this.

Is there a better way to get a color cycle? Right now I'm hard coding the thing.
