### PR TITLE
Bugfix: Apply visual mapping for geom aesthetics

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -294,9 +294,9 @@ class ggplot(object):
                         _aes.update(geom.aes)
                     if not geom.data is None:
                         data = _apply_transforms(geom.data, _aes)
-                        data = assign_visual_mapping(data, _aes, self)
                     else:
                         data = self.data
+                    data = assign_visual_mapping(data, _aes, self)
                     for layer in self._get_layers(data, _aes):
                         ax = plt.subplot(1, 1, 1)
                         callbacks = geom.plot_layer(layer)


### PR DESCRIPTION
**Issue**

Aesthetics `aes` for colors, shapes, size and linestyles
applied to geoms lead to an error.

This code fails.

``` python
N = 25
df = pd.DataFrame(np.random.rand(N, 2), columns=list('xy'))
df['area'] = np.random.rand(N) * 100

(ggplot(df, aes('x', 'y', size='area')) +
 geom_point(aes(alpha=0.8)))
```

**Problem**
The line of code that assigns visual aesthetics is
in the wrong place.

**Solution**
Move the line of code so that it also applies to
geom aesthetics.
