### PR TITLE
Fix: py3 unfriendly imports in qplot

### DIFF
--- a/ggplot/qplot.py
+++ b/ggplot/qplot.py
@@ -1,6 +1,6 @@
 from ggplot import *
-from ggplot import xlab as xlabel
-from ggplot import ylab as ylabel
+from .geoms.chart_components import xlab as xlabel
+from .geoms.chart_components import ylab as ylabel
 import pandas as pd
 
 


### PR DESCRIPTION
**Issue**
Python 3 tests fails at

`from ggplot import xlab as xlabel`

in qplot.py

**Problem**
xlab is imported into ggplot as a `*`. This is not
an explicit import and python 3 does not like it.

**Solution**
Change the import statements to import xlab and ylab
from where they are explicitly defined
