### PR TITLE
Add checks to chart components on init.

### DIFF
--- a/ggplot/geoms/chart_components.py
+++ b/ggplot/geoms/chart_components.py
@@ -1,9 +1,14 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from copy import deepcopy
+from ggplot.utils.exceptions import GgplotError
+
 
 class ggtitle(object):
     def __init__(self, title):
+        if title is None:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "cannot be None")
         self.title = title
 
     def __radd__(self, gg):
@@ -11,17 +16,17 @@ class ggtitle(object):
         gg.title = self.title
         return gg
 
-class xlab(object):
-    def __init__(self, xlab):
-        self.xlab = xlab
-
-    def __radd__(self, gg):
-        gg = deepcopy(gg)
-        gg.xlab = self.xlab
-        return gg
 
 class xlim(object):
     def __init__(self, low, high):
+        if low is None or high is None:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "cannot be None")
+        try:
+            _ = high - low
+        except TypeError:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "must be of a numeric type")
         self.low, self.high = low, high
 
     def __radd__(self, gg):
@@ -29,8 +34,17 @@ class xlim(object):
         gg.xlimits = [self.low, self.high]
         return gg
 
+
 class ylim(object):
     def __init__(self, low, high):
+        if low is None or high is None:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "cannot be None")
+        try:
+            _ = high - low
+        except TypeError:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "must be of a numeric type")
         self.low, self.high = low, high
 
     def __radd__(self, gg):
@@ -38,14 +52,32 @@ class ylim(object):
         gg.ylimits = [self.low, self.high]
         return gg
 
+
+class xlab(object):
+    def __init__(self, xlab):
+        if xlab is None:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "cannot be None")
+        self.xlab = xlab
+
+    def __radd__(self, gg):
+        gg = deepcopy(gg)
+        gg.xlab = self.xlab
+        return gg
+
+
 class ylab(object):
     def __init__(self, ylab):
+        if ylab is None:
+            raise GgplotError("Arguments to", self.__class__.__name__,
+                              "cannot be None")
         self.ylab = ylab
 
     def __radd__(self, gg):
         gg = deepcopy(gg)
         gg.ylab = self.ylab
         return gg
+
 
 class labs(object):
     def __init__(self, x=None, y=None, title=None):

--- a/ggplot/tests/__init__.py
+++ b/ggplot/tests/__init__.py
@@ -28,7 +28,8 @@ default_test_modules = [
     'ggplot.tests.test_ggsave',
     'ggplot.tests.test_theme_mpl',
     'ggplot.tests.test_colors',
-    ]
+    'ggplot.tests.test_chart_components',
+]
 
 
 _multiprocess_can_split_ = True

--- a/ggplot/tests/test_chart_components.py
+++ b/ggplot/tests/test_chart_components.py
@@ -1,0 +1,72 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+import pandas as pd
+
+from nose.tools import assert_raises, assert_equal, assert_is_none
+
+from ggplot import *
+from ggplot.utils.exceptions import GgplotError
+
+
+def test_chart_components():
+    """
+    Test invalid arguments to chart components
+    """
+
+    df = pd.DataFrame({'x': np.arange(10),
+                       'y': np.arange(10)})
+
+    gg = ggplot(df, aes(x='x', y='y'))
+
+    # test ggtitle
+    assert_raises(GgplotError, ggtitle, None)
+
+    # test xlim
+    assert_raises(GgplotError, xlim, 0, None)
+    assert_raises(GgplotError, xlim, None, 0)
+    assert_raises(GgplotError, xlim, None, None)
+    assert_raises(GgplotError, xlim, "foo", 1)
+    assert_raises(GgplotError, xlim, "foo", "bar")
+
+    # test ylim
+    assert_raises(GgplotError, ylim, 0, None)
+    assert_raises(GgplotError, ylim, None, 0)
+    assert_raises(GgplotError, ylim, None, None)
+    assert_raises(GgplotError, ylim, "foo", 1)
+    assert_raises(GgplotError, ylim, "foo", "bar")
+
+    # test xlab
+    assert_raises(GgplotError, ylab, None)
+
+    # test ylab
+    assert_raises(GgplotError, ylab, None)
+
+    # test labs
+    test_xlab = 'xlab'
+    gg_xlab = gg + labs(x=test_xlab)
+
+    assert_equal(gg_xlab.xlab, test_xlab)
+    assert_is_none(gg_xlab.ylab)
+    assert_is_none(gg_xlab.title)
+
+    test_ylab = 'ylab'
+    gg_ylab = gg + labs(y=test_ylab)
+
+    assert_is_none(gg_ylab.xlab)
+    assert_equal(gg_ylab.ylab, test_ylab)
+    assert_is_none(gg_ylab.title)
+
+    test_title = 'title'
+    gg_title = gg + labs(title=test_title)
+
+    assert_is_none(gg_title.xlab)
+    assert_is_none(gg_title.ylab)
+    assert_equal(gg_title.title, test_title)
+
+    gg_labs = gg + labs(x=test_xlab, y=test_ylab, title=test_title)
+
+    assert_equal(gg_labs.xlab, test_xlab)
+    assert_equal(gg_labs.ylab, test_ylab)
+    assert_equal(gg_labs.title, test_title)

--- a/ggplot/utils/exceptions.py
+++ b/ggplot/utils/exceptions.py
@@ -1,0 +1,13 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+
+class GgplotError(Exception):
+    """
+    Exception for ggplot errors
+    """
+    def __init__(self, *args):
+        self.message = " ".join(args)
+
+    def __str__(self):
+        return repr(self.message)


### PR DESCRIPTION
Check for components that should never be None and check for components that should be of a numeric type. I figure it makes more sense to throw the error early. This is in response to https://github.com/yhat/ggplot/issues/255
