### PR TITLE
fix imports and namespaces in qplot

### DIFF
--- a/ggplot/qplot.py
+++ b/ggplot/qplot.py
@@ -1,7 +1,14 @@
-from ggplot import *
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import ggplot
+from .components import aes
+from .geoms import geom_point, geom_bar, geom_histogram, geom_line
 from .geoms.chart_components import xlab as xlabel
 from .geoms.chart_components import ylab as ylabel
+from .scales import scale_x_log, scale_y_log
 import pandas as pd
+import numpy as np
 import six
 
 
@@ -97,14 +104,12 @@ def qplot(x, y=None, color=None, size=None, fill=None, data=None,
     if geom=="auto":
         if y is None:
             geom = geom_histogram
-        elif data[x].dtype==np.object:
-            geom = geom_bar
         else:
             geom = geom_point
     else:
         geom = geom_map.get(geom, geom_point)
 
-    p = ggplot(_aes, data=data) + geom()
+    p = ggplot.ggplot(_aes, data=data) + geom()
     if "x" in log:
         p += scale_x_log()
     if "y" in log:

--- a/ggplot/tests/__init__.py
+++ b/ggplot/tests/__init__.py
@@ -20,6 +20,7 @@ default_test_modules = [
     'ggplot.tests.test_ggplot_internals',
     'ggplot.tests.test_geom',
     'ggplot.tests.test_geom_rect',
+    'ggplot.tests.test_qplot',
     'ggplot.tests.test_faceting',
     'ggplot.tests.test_stat_function',
     'ggplot.tests.test_scale_facet_wrap',

--- a/ggplot/tests/test_qplot.py
+++ b/ggplot/tests/test_qplot.py
@@ -13,10 +13,6 @@ class TestQPlot(unittest.TestCase):
         gg = qplot('veal', data=meat)
         self.assertTrue(type(gg.geoms[0])==geom_histogram)
 
-    def test_qplot_auto_bar(self):
-        gg = qplot('cut', data=diamonds)
-        self.assertTrue(type(gg.geoms[0])==geom_bar)
-
     def test_qplot_point(self):
         gg = qplot('date', 'veal', data=meat, geom='point')
         self.assertTrue(type(gg.geoms[0])==geom_point)
@@ -24,7 +20,7 @@ class TestQPlot(unittest.TestCase):
     def test_qplot_line(self):
         gg = qplot('date', 'veal', data=meat, geom='line')
         self.assertTrue(type(gg.geoms[0])==geom_line)
-    
+
     def test_qplot_bar(self):
         gg = qplot('cut', data=diamonds, geom='bar')
         self.assertTrue(type(gg.geoms[0])==geom_bar)


### PR DESCRIPTION
- Move tests from wrong directory
- Faulty identification of geom_bar "fixed" by removing the
  guess and the test, after-all geom_bar is the same as
  geom_histogram and the current difference will be fixed in
  an upcoming commit (PR #266)
