### PR TITLE
Overlapping legend boxes fix

### DIFF
--- a/ggplot/components/legend.py
+++ b/ggplot/components/legend.py
@@ -61,7 +61,7 @@ def add_legend(legend, ax):
         nb_rows += rows + 1
         if nb_rows > max(max_rows, rows + 1) :
             nb_cols += 1
-            nb_rows = 0
+            nb_rows = rows + 1
             cur_nb_rows = 0
         anchor_legend(ax, legend_box, cur_nb_rows, nb_cols)
 


### PR DESCRIPTION
I humbly offer a one-line fix.

I came across a small bug today with overlapping legend boxes. It turns out that when a new column is needed for the legend boxes, the running count of legend rows is erroneously reset to zero.

If there is sufficient room below the last created legend and if the last created legend was put on a new column, the running sum of rows would be set to zero and the next legend would be placed on the top of the column instead of below the last created legend.

![before](https://cloud.githubusercontent.com/assets/2652029/4038562/9a953bb6-2cb7-11e4-914c-54b654f1b34f.png)

(The script used to generate these plots can be found at https://gist.github.com/KelvinLu/eb48e9b0e147953d455c)

Changing the one line results in:

![after](https://cloud.githubusercontent.com/assets/2652029/4038561/9a95027c-2cb7-11e4-8ef8-cabcc84cfa99.png)

tests.py encountered one error about not being able to find a new dotplot geom module, which I don't believe is about this issue. All the images looked OK in my spot check of the results.

![capture](https://cloud.githubusercontent.com/assets/2652029/4038700/7f75a778-2cba-11e4-80fa-98455811480c.PNG)
