### PR TITLE
Fixed compatibility with python 3.x

### DIFF
--- a/ggplot/components/palettes.py
+++ b/ggplot/components/palettes.py
@@ -8,7 +8,7 @@ import matplotlib as mpl
 from six import string_types
 from six.moves import range
 
-import husl
+from . import husl
 from .xkcd_rgb import xkcd_rgb
 
 


### PR DESCRIPTION
Python 3.x will not load the husl module unless it is specified that its location is relative to the palettes.py file.
