### PR TITLE
allow 'python setup.py sdist bdist_wheel'

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
add missing file to get an universal  .whl package on pypi
