### PR TITLE
Fix for py 3

### DIFF
--- a/ggplot/components/palettes.py
+++ b/ggplot/components/palettes.py
@@ -8,7 +8,7 @@ import matplotlib as mpl
 from six import string_types
 from six.moves import range
 
-import husl
+from . import husl
 from .xkcd_rgb import xkcd_rgb
 
 


### PR DESCRIPTION
py 3 install gives an error on import:

```
/usr/local/lib/python3.4/dist-packages/ggplot/components/palettes.py in <module>()
      9 from six.moves import range
     10 
---> 11 import husl
     12 from .xkcd_rgb import xkcd_rgb
     13 


ImportError: No module named 'husl'
```
