### PR TITLE
Implemented a baseline geom_tile.

### DIFF
--- a/ggplot/geoms/geom.py
+++ b/ggplot/geoms/geom.py
@@ -74,6 +74,10 @@ class geom(object):
         self._stat_type = self._get_stat_type(kwargs)
         self.aes, self.data, kwargs = self._find_aes_and_data(args, kwargs)
 
+        # This set will list the geoms that were uniquely set in this
+        # geom (not specified already i.e. in the ggplot aes).
+        self.aes_unique_to_geom = set(self.aes.keys())
+
         if 'colour' in kwargs:
             kwargs['color'] = kwargs.pop('colour')
 
@@ -160,11 +164,13 @@ class geom(object):
         gg = deepcopy(gg)
         # steal aesthetics info.
         self._cache['ggplot.aesthetics'] = deepcopy(gg.aesthetics)
+        self.aes_unique_to_geom -= set(gg.aesthetics.keys())
         # create stat and hand over the parameters it understands
         if not hasattr(self, '_stat'):
             self._stat = self._stat_type()
             self._stat.params.update(self._stat_params)
         gg.geoms.append(self)
+        self.gg = gg
         return gg
 
     def _verify_aesthetics(self, data):

--- a/ggplot/geoms/geom_tile.py
+++ b/ggplot/geoms/geom_tile.py
@@ -1,33 +1,99 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import pandas as pd
+import numpy as np
 from .geom import geom
-
+from matplotlib.patches import Rectangle
+import matplotlib.colors as colors
+import matplotlib.colorbar as colorbar
 
 class geom_tile(geom):
 
-    DEFAULT_AES = {'alpha': None, 'color': '#333333', 'fill': '#333333',
-                   'linetype': 'solid', 'size': 0.1}
-    REQUIRED_AES = {'x', 'y'}
+    DEFAULT_AES = {}
+    REQUIRED_AES = {'x', 'y', 'fill'}
     DEFAULT_PARAMS = {'stat': 'identity', 'position': 'identity'}
 
-    _aes_renames = {'linetype': 'linestyle', 'size': 'linewidth',
-                    'fill': 'color', 'color': 'edgecolor'}
-    _units = {'color', 'edgecolor', 'linestyle', 'linewidth'}
+    _aes_renames = {}
+    _units = set()
 
     def _plot_unit(self, pinfo, ax):
-        # TODO: Reimplement this
         x = pinfo.pop('x')
         y = pinfo.pop('y')
         fill = pinfo.pop('fill')
-        X = pd.DataFrame({'x': x,
-                          'y': y,
-                          'fill': fill}).set_index(['x', 'y']).unstack(0)
-        x_ticks = range(0, len(set(x)))
-        y_ticks = range(0, len(set(y)))
 
-        ax.imshow(X, interpolation='nearest', **pinfo)
-        ax.set_xticklabels(x)
+        # TODO: Fix this hack!
+        # Currently, if the fill is specified in the ggplot aes wrapper, ggplot
+        # will assign colors without regard to the fill values. This is okay for
+        # categorical maps but not heatmaps. At this stage in the pipeline the
+        # geom can't recover the original values.
+        #
+        # However, if the fill is specified in the geom_tile aes wrapper, the
+        # original fill values are sent unaltered, so we can make a heat map
+        # with the values.
+
+        # Was the fill specified in geom wrapper only? (i.e. not in ggplot)
+        if 'fill' in self.aes_unique_to_geom:
+            # Determine if there are non-numeric values.
+            if False in [isinstance(v, (int, long, float, complex)) for v in set(fill)]:
+                # No need to handle this case. Instruct the user to put categorical
+                # values in the ggplot wrapper.
+                raise Exception('For categorical fill values specify fill in the ggplot aes instead of the geom_tile aes.')
+
+            # All values are numeric so determine fill using colormap.
+            else:
+                fill_min  = np.min(fill)
+                fill_max  = np.max(fill)
+
+                if np.isnan(fill_min):
+                    raise Exception('Fill values cannot contain NaN values.')
+
+                fill_rng  = float(fill_max - fill_min)
+                fill_vals = (fill - fill_min) / fill_rng
+
+                cmap = self.gg.colormap(fill_vals.tolist())
+                fill      = [colors.rgb2hex(c) for c in cmap[::, :3]]
+
+        df = pd.DataFrame(
+            {'x': x, 'y': y, 'fill': fill}).set_index(['x', 'y']).unstack(0)
+
+        # Setup axes.
+        x_ticks   = range(2*len(set(x)) + 1)
+        y_ticks   = range(2*len(set(y)) + 1)
+
+        x_indices = sorted(set(x))
+        y_indices = sorted(set(y))
+
+        # Setup box plotting parameters.
+        x_start   = 0
+        y_start   = 0
+        x_step    = 2
+        y_step    = 2
+
+        # Plot grid.
+        on_y = y_start
+        for yi in xrange(len(y_indices)):
+            on_x = x_start
+            for xi in xrange(len(x_indices)):
+                color = df.iloc[yi,xi]
+                if not isinstance(color, float):
+                    ax.add_patch(Rectangle((on_x, on_y), x_step, y_step, facecolor=color))
+                on_x += x_step
+            on_y += y_step
+
+        # Draw the colorbar scale if drawing a heat map.
+        if 'cmap' in locals():
+            norm = colors.Normalize(vmin = fill_min, vmax = fill_max)
+            cax, kw = colorbar.make_axes(ax)
+            cax.hold(True)
+            colorbar.ColorbarBase(cax, cmap = self.gg.colormap, norm = norm)
+
+        # Set axis labels and ticks.
+        x_labels = ['']*(len(x_indices)+1)
+        for i,v in enumerate(x_indices): x_labels.insert(2*i+1, v)
+        y_labels = ['']*(len(y_indices)+1)
+        for i,v in enumerate(y_indices): y_labels.insert(2*i+1, v)
+
+        ax.set_xticklabels(x_labels)
         ax.set_xticks(x_ticks)
-        ax.set_yticklabels(y)
+        ax.set_yticklabels(y_labels)
         ax.set_yticks(y_ticks)


### PR DESCRIPTION
This was made to address #301 by adding some basic capability.
It doesn't completely address #293 since I was lazy and didn't
write any unit tests. :-)

The tile geom now creates a tiled geom similar to R ggplot2 with
some caveats:
- If you add the fill parameter to the ggplot aes wrapper, ggplot
  will arbitrarily map colors without taking into account ordering
  of the fill values, which can't (as far as I know) be stopped
  by the geom coming down the pipe. If sent this way, the geom gets
  the already mapped fill values and is unable to recover their
  numeric values to make a heat map image, so all geom_tile plots
  drawn like this are deemed 'categorical'.
- If you add the fill parameter to geom_tile's aes wrapper, the
  actuall fill values are sent, so geom_tile can use them to make
  a heatmap. This is the only way to do that.
- If you want to set the color range for a heat map, you have to
  do it before sending the geom.

So as far as useability is concerned:
- If you want to tile categorical data, you must put the fill in
  the ggplot aes.
- If you want to make a heat map, you must put the fill in the
  geom aes.
- For heat maps, send color gradients before the geom.

(Technically one can get around the first restriction by duplicating
code in the geom, but I chose to issue an Exception instead to avoid
duplicating code).

Some examples of use:

```
# For categorical data, put in the ggplot aes wrapper.
ggplot(aes(x='x', y='y', fill='fill'), data=df) + geom_tile()

# For a heat map, put in geom aes wrapper.
ggplot(aes(x='x', y='y'), data=df) + geom_tile(aes(fill='fill'))

# If fill is sent in both wrappers, a categorical view will be
# chosen.

# Send color gradients for the heat map first.
ggplot(aes(x='x', y='y'), data=df) + scale_color_gradient(low='blue', mid='white', high='red') + geom_tile(aes(fill='fill'))
```
