### PR TITLE
Fix fill randomly not working in geom_bar + geom_histogram

### DIFF
--- a/ggplot/geoms/geom.py
+++ b/ggplot/geoms/geom.py
@@ -67,15 +67,12 @@ class geom(object):
         # parameters passed to the geom itself override the aesthetics
         mpl_params.update(self.params)
 
-        items = list(mpl_params.items())
-        for key, value in items:
-            
+        for key in list(mpl_params):
             if key not in self.VALID_AES:
                 del mpl_params[key]
-            elif key in self._aes_renames:
-                new_key = self._aes_renames[key]
-                mpl_params[new_key] = value
-                del mpl_params[key]
+        for key, new_key in self._aes_renames.copy().items():
+            if key in mpl_params:
+                mpl_params[new_key] = mpl_params.pop(key)
 
         for req in self.REQUIRED_AES:
             if req not in mpl_params:

--- a/ggplot/geoms/geom_bar.py
+++ b/ggplot/geoms/geom_bar.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from .geom import geom
 import pandas as pd
 import matplotlib.patches as patches
@@ -30,8 +31,12 @@ class geom_bar(geom):
                    'linetype': 'solid', 'size': 1.0}
     REQUIRED_AES = {'x'}
     DEFAULT_PARAMS = {"width": 0.8}
-    _aes_renames = {'linetype': 'linestyle', 'size': 'linewidth',
-                    'fill': 'color', 'color': 'edgecolor'}
+    _aes_renames = OrderedDict([
+        ('linetype', 'linestyle'),
+        ('size', 'linewidth'),
+        ('color', 'edgecolor'), # Before fill -> color
+        ('fill', 'color'),
+    ])
 
     def setup_data(self, data, _aes, facets=None):
         (data, _aes) = self._update_data(data, _aes)

--- a/ggplot/geoms/geom_histogram.py
+++ b/ggplot/geoms/geom_histogram.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from .geom import geom
 import numpy as np
 
@@ -33,8 +34,12 @@ class geom_histogram(geom):
                    'linetype': 'solid', 'size': 1.0}
     REQUIRED_AES = {'x'}
     DEFAULT_PARAMS = {'bins': 10}
-    _aes_renames = {'linetype': 'linestyle', 'size': 'linewidth',
-                    'fill': 'color', 'color': 'edgecolor'}
+    _aes_renames = OrderedDict([
+        ('linetype', 'linestyle'),
+        ('size', 'linewidth'),
+        ('color', 'edgecolor'), # Before fill -> color
+        ('fill', 'color'),
+    ])
 
     def plot(self, ax, data, _aes):
         (data, _aes) = self._update_data(data, _aes)


### PR DESCRIPTION
This code randomly produces one of two graphs:
```py
ggplot(diamonds, aes(x='clarity', fill='cut')) + geom_bar()
```

| sometimes good | sometimes bad
|---|---
| ![fig-20161123t060033416866](https://cloud.githubusercontent.com/assets/627486/20552470/3b6e98a6-b100-11e6-9159-f3e966c58840.png) | ![fig-20161123t052330808668](https://cloud.githubusercontent.com/assets/627486/20552471/3e9ef53e-b100-11e6-8c33-4f9eb114f3c3.png)

Problem: `geom._get_plot_args` renames keys in `mpl_params` according to `_aes_renames`, but not in a deterministic order. In particular, `geom_bar` and `geom_histogram` both include renames:

- `color` -> `edgecolor`
- `fill` -> `color`

which when done in that order are fine but in the other order causes `color` to get dropped.

Solution: use `OrderedDict` in `geom_bar` and `geom_histogram` to ensure that the `color` -> `edgecolor` rename happens before the `fill` -> `color` rename.