### PR TITLE
resolves issue  #580

### DIFF
--- a/ggplot/geoms/geom_ribbon.py
+++ b/ggplot/geoms/geom_ribbon.py
@@ -1,6 +1,7 @@
 from .geom import geom
 from ..utils import is_date
 import numpy as np
+from ..ggplot import ggplot
 
 class geom_ribbon(geom):
     """
@@ -35,6 +36,21 @@ class geom_ribbon(geom):
     DEFAULT_PARAMS = {}
 
     _aes_renames = {'linetype': 'linestyle', 'size': 'linewidth', 'fill': 'facecolor', 'color': 'edgecolor'}
+
+
+    def __radd__(self, gg):
+        if isinstance(gg, ggplot):
+            gg.layers += self.layers
+            if self.geom_aes is not None:
+                for aes_key in ['fill', ]:
+                    if aes_key in self.geom_aes:
+                        gg._aes[aes_key] = self.geom_aes.pop(aes_key)
+            return gg
+
+        self.layers.append(gg)
+        return self
+
+
     def plot(self, ax, data, _aes):
         (data, _aes) = self._update_data(data, _aes)
         params = self._get_plot_args(data, _aes)

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -53,9 +53,6 @@ class ggplot(object):
         self._aes = aesthetics
         self.data = data.copy()
         self._handle_index()
-        self.data = self._aes._evaluate_expressions(self.data)
-        self.data = self._aes.handle_identity_values(self.data)
-
 
         self.layers = []
 
@@ -353,6 +350,9 @@ class ggplot(object):
 
     def _construct_plot_data(self):
         "Splits up the main data based on discrete aesthetics into sub-data frames"
+        #parsing aes relocated here from __init__ to allow for aes expressions to be supplied in subsequent geom_*()
+        self.data = self._aes._evaluate_expressions(self.data)
+        self.data = self._aes.handle_identity_values(self.data)
         data = self.data
         discrete_aes = self._aes._get_discrete_aes(data)
         mappers = {}


### PR DESCRIPTION
1) amends `__radd__` for `geom_ribbon` so that it transfers `aes(fill=...)` to the `ggplot` class object 

2) moves expression parsing from `ggplot.__init__` to `_construct_plot_data` to allow parsing of the `fill` (and possibly other aesthetics supplied in subsequent geometries).