### PR TITLE
pandas v0.19 sort_values compatibility (Fixes #612)

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -599,7 +599,11 @@ class ggplot(object):
             if 'fill' in self._aes:
                 fillcol_raw = self._aes['fill'][:-5]
                 fillcol = self._aes['fill']
-                fill_levels = self.data[[fillcol_raw, fillcol]].sort(fillcol_raw)[fillcol].unique()
+                try:  # change in pandas v0.19
+                    fill_levels = self.data[[fillcol_raw, fillcol]].sort_values(fillcol_raw)[fillcol].unique()
+                except:  # before pandas v0.19
+                    fill_levels = self.data[[fillcol_raw, fillcol]].sort(fillcol_raw)[fillcol].unique()
+
             else:
                 fill_levels = None
             return dict(x_levels=self.data[self._aes['x']].unique(), fill_levels=fill_levels, lookups=df)


### PR DESCRIPTION
Backwards compatible fix for pandas switching to `.sort_values()` from `.sort()` after version 0.19

Solves Issue #612 