### PR TITLE
pandas-0.19 compatibility

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -599,7 +599,10 @@ class ggplot(object):
             if 'fill' in self._aes:
                 fillcol_raw = self._aes['fill'][:-5]
                 fillcol = self._aes['fill']
-                fill_levels = self.data[[fillcol_raw, fillcol]].sort(fillcol_raw)[fillcol].unique()
+                try:  # change in Pandas-0.19
+                    fill_levels = self.data[[fillcol_raw, fillcol]].sort_values(by=fillcol_raw)[fillcol].unique()
+                except:  # before Pandas-0.19
+                    fill_levels = self.data[[fillcol_raw, fillcol]].sort(fillcol_raw)[fillcol].unique()
             else:
                 fill_levels = None
             return dict(x_levels=self.data[self._aes['x']].unique(), fill_levels=fill_levels, lookups=df)


### PR DESCRIPTION
sort was completely removed from the Pandas 0.20.0
 
fix issue similar to:
https://github.com/yhat/ggpy/commit/9d00182343eccca6486beabd256e8c89fb0c59e8

encounter with this issue when in python3.6, I was trying to run: 
https://stackoverflow.com/a/37491952/4642669