### PR TITLE
Make geom_hline and geom_vline consistent with documentation and with R's ggplot2

### DIFF
--- a/ggplot/geoms/geom_hline.py
+++ b/ggplot/geoms/geom_hline.py
@@ -28,7 +28,13 @@ class geom_hline(geom):
         (data, _aes) = self._update_data(data, _aes)
         params = self._get_plot_args(data, _aes)
         variables = _aes.data
-        y = self.params.get('y')
+        y = self.params.get('yintercept')
+        # for backwards compatibility, allow setting 'y'
+        if y is None:
+            y = self.params.get('y')    
+        if y is None:
+            raise ValueError("yintercept is required for hline")
+        
         if is_iterable(y):
             for yi in y:
                 ax.axhline(yi, **params)

--- a/ggplot/geoms/geom_vline.py
+++ b/ggplot/geoms/geom_vline.py
@@ -27,8 +27,13 @@ class geom_vline(geom):
         (data, _aes) = self._update_data(data, _aes)
         params = self._get_plot_args(data, _aes)
         variables = _aes.data
-        x = self.params.get('x')
-
+        x = self.params.get('xintercept')
+        # for backwards compatibility, allow setting 'x'
+        if x is None:
+            x = self.params.get('x')    
+        if x is None:
+            raise ValueError("xintercept is required for vline")
+        
         if is_iterable(x):
             for xi in x:
                 ax.axvline(xi, **params)


### PR DESCRIPTION
This change fixes #597 and #545, both to match the docs, and to make it more consistent with [ggplot2 ](http://www.cookbook-r.com/Graphs/Lines_(ggplot2)/)(it uses 'yintercept' and 'xintercept', which is why [some docs ](http://ggplot.yhathq.com/docs/geom_hline.html)do too), while maintaining backward compatibility with those who have used the 'x' or 'y' param, since that's all you could do to get it working previously. 

Also toss a ValueError if neither x/y nor xintercept/yintercept are set when plotting (instead of ambiguous and unhelpful type comparison exception).

Looks like that makes [this doc](http://yhat.github.io/ggpy/notebook.html?page=build/docs/examples/Plotting%20a%20Horizontal%20Line.html) incorrect, though. Will fix that one next.