### PR TITLE
Make save_as_base64 python 3 compatible

### DIFF
--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -570,7 +570,7 @@ class ggplot(object):
         height: int, float
             height of the plot in inches
         """
-        imgdata = six.StringIO()
+        imgdata = six.BytesIO()
         self.save(imgdata, width=width, height=height, dpi=dpi)
         imgdata.seek(0)  # rewind the data
         uri = 'data:image/png;base64,' + urllib.quote(base64.b64encode(imgdata.buf))

--- a/ggplot/ggplot.py
+++ b/ggplot/ggplot.py
@@ -573,7 +573,7 @@ class ggplot(object):
         imgdata = six.BytesIO()
         self.save(imgdata, width=width, height=height, dpi=dpi)
         imgdata.seek(0)  # rewind the data
-        uri = 'data:image/png;base64,' + urllib.quote(base64.b64encode(imgdata.buf))
+        uri = 'data:image/png;base64,' + urllib.quote(base64.b64encode(imgdata.read()))
         if as_tag==True:
             return '<img src = "%s"/>' % uri
         else:


### PR DESCRIPTION
`six.BytesIO` is a fake file object for binary data. In Python 2, it’s an alias for StringIO.StringIO, but in Python 3, it’s an alias for io.BytesIO.