### PR TITLE
change to imports for pandas Timestamp module

### DIFF
--- a/ggplot/stats/smoothers.py
+++ b/ggplot/stats/smoothers.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from pandas.lib import Timestamp
+from pandas import Timestamp
 import pandas as pd
 import statsmodels.api as sm
 from statsmodels.nonparametric.smoothers_lowess import lowess as smlowess


### PR DESCRIPTION
pandas 0.23.0
ggplot 0.11.5

changed `from pandas.lib import Timestamp` to `from pandas import Timestamp`, might break compability with old pandas.

an alternative may be to do a try except....? which might look pretty bad, but I haven't really researched into how to support multiple pandas versions with different import endpoints.

reference: https://stackoverflow.com/questions/50591982/importerror-cannot-import-name-timestamp