### PR TITLE
fixing incompatibility with pandas>=0.20.0

### DIFF
--- a/ggplot/stats/smoothers.py
+++ b/ggplot/stats/smoothers.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from pandas.lib import Timestamp
+from pandas import Timestamp
 import pandas as pd
 import statsmodels.api as sm
 from statsmodels.nonparametric.smoothers_lowess import lowess as smlowess
@@ -11,7 +11,7 @@ import scipy.stats as stats
 import datetime
 
 date_types = (
-    pd.tslib.Timestamp,
+    pd.Timestamp,
     pd.DatetimeIndex,
     pd.Period,
     pd.PeriodIndex,

--- a/ggplot/utils.py
+++ b/ggplot/utils.py
@@ -78,7 +78,7 @@ def is_iterable(obj):
         return False
 
 date_types = (
-    pd.tslib.Timestamp,
+    pd.Timestamp,
     pd.DatetimeIndex,
     pd.Period,
     pd.PeriodIndex,


### PR DESCRIPTION
Pandas made some modules private and deprecated: https://pandas.pydata.org/pandas-docs/stable/whatsnew.html#modules-privacy-has-changed
The moved Timestamp class is available from top-level namespace.

This patch fixes #617 and #618. I have tested it with pandas back to version v0.17.0 (October 9, 2015) under Python 3.6 .
Older versions were not tested as they do not compile on my machine out-of-the-box. Test reports with older versions are appreciated.