### PR TITLE
Add a dynamic import of timestamp from pandas

### DIFF
--- a/ggplot/stats/smoothers.py
+++ b/ggplot/stats/smoothers.py
@@ -1,7 +1,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 import numpy as np
-from pandas.lib import Timestamp
+try:
+    from pandas.lib import Timestamp
+except ImportError:
+    from pandas import Timestamp
 import pandas as pd
 import statsmodels.api as sm
 from statsmodels.nonparametric.smoothers_lowess import lowess as smlowess


### PR DESCRIPTION
Pandas seems to have moved the timestamp import over version, see this [issue] on stack overflow (https://stackoverflow.com/questions/50591982/importerror-cannot-import-name-timestamp)

Note that I had this issue separately from the SO question so it's at least somewhat widespread